### PR TITLE
Calculate entry_hash from routing_identification, not routing_number

### DIFF
--- a/lib/headache/batch.rb
+++ b/lib/headache/batch.rb
@@ -79,7 +79,7 @@ module Headache
     end
 
     def entry_hash
-      @entry_hash || entries.map(&:routing_number).map(&:to_i).sum
+      @entry_hash || entries.map(&:routing_identification).map(&:to_i).sum
     end
 
     def add_entry(entry)

--- a/spec/factories/headache/record/entries.rb
+++ b/spec/factories/headache/record/entries.rb
@@ -10,4 +10,10 @@ FactoryGirl.define do
     f.individual_name 'Bob Smith'
     f.transaction_code 'abc123def456'
   end
+
+  factory :another_entry, parent: :entry do |f|
+    f.routing_number '111111119'
+  end
+
+
 end

--- a/spec/headache/batch_spec.rb
+++ b/spec/headache/batch_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Headache::Batch do
+  subject { described_class.new }
+
+  it 'should correctly compute the entry_hash value from the routing identification number' do
+    subject << create(:entry)
+    expect { subject << create(:another_entry) }
+      .to change { subject.entry_hash }
+      .from(55555555)
+      .to(66666666)
+  end
+
+end


### PR DESCRIPTION
This PR fixes a critical bug in the way a batch's `entry_hash` value is calculated.

As per [NACHA spec](http://cs.thomsonreuters.com/ua/acct_pr/csa/cs_us_en/pr/pr_dd/company_batch_control_record.htm), the `entry_hash` value should be a sum of all RDFI (routing) _identification_ values which is **the first eight digits** (minus the `check_digit`) of the full routing _number_.