### PR TITLE
Ensure transaction_code is present when calling #generate

### DIFF
--- a/lib/headache/record/entry.rb
+++ b/lib/headache/record/entry.rb
@@ -14,6 +14,11 @@ module Headache
         rval
       end
 
+      def generate(*args)
+        fail ArgumentError, 'transaction_code cannot be blank' unless transaction_code.present?
+        super(*args)
+      end
+
       def routing_identification=(value)
         rval = (@routing_identification = value)
         assemble_routing_number

--- a/lib/headache/version.rb
+++ b/lib/headache/version.rb
@@ -1,3 +1,3 @@
 module Headache
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/spec/headache/record/entry_spec.rb
+++ b/spec/headache/record/entry_spec.rb
@@ -12,4 +12,9 @@ describe Headache::Record::Entry do
     expect(line).to eq("6AB5555555555555555555       0000010000ABC123         BOB SMITH               0DEF456         ")
   end
 
+  it 'raises an exception if transactino_code is empty' do
+    entry = build :entry, transaction_code: nil
+    expect { entry.generate }.to raise_error(ArgumentError)
+  end
+
 end

--- a/spec/headache/record/entry_spec.rb
+++ b/spec/headache/record/entry_spec.rb
@@ -12,7 +12,7 @@ describe Headache::Record::Entry do
     expect(line).to eq("6AB5555555555555555555       0000010000ABC123         BOB SMITH               0DEF456         ")
   end
 
-  it 'raises an exception if transactino_code is empty' do
+  it 'raises an exception if transaction_code is empty' do
     entry = build :entry, transaction_code: nil
     expect { entry.generate }.to raise_error(ArgumentError)
   end


### PR DESCRIPTION
Stopgap measure to ensure `transaction_code` is present when generating an ACH entry record.

Eventually we'll need a better solution for record validations. Probably wise to mix-in `ActiveModel::Validations`, but will tackle that in a separate PR.