### PR TITLE
Remove the ability to specify custom record classes

### DIFF
--- a/lib/headache.rb
+++ b/lib/headache.rb
@@ -4,6 +4,7 @@ require 'active_support/concern'
 require 'active_support/core_ext/string'
 require 'active_support/core_ext/enumerable'
 
+require 'headache/exception'
 require 'headache/formatters'
 require 'headache/definitions'
 require 'headache/record/base'

--- a/lib/headache/batch.rb
+++ b/lib/headache/batch.rb
@@ -8,35 +8,19 @@ module Headache
                   :entry_class_code, :entry_description, :descriptive_date,
                   :total_debit, :total_credit, :entry_hash
 
-    @@record_classes = { header: Record::BatchHeader,
-                         control: Record::BatchControl }
-
-    def self.header=(klass)
-      set_class :header, klass
-    end
-
-    def self.control=(klass)
-      set_class :control, klass
-    end
-
-    def self.set_class(type, klass)
-      fail "unknown record class: #{type}" unless @@record_classes[type].present?
-      @@record_classes[type] = klass
-    end
-
     def parse(records)
-      @header  = @@record_classes[:header].new(self, @document).parse(records.shift)
-      @control = @@record_classes[:control].new(self, @document).parse(records.pop)
+      @header  = Record::BatchHeader.new(self, @document).parse(records.shift)
+      @control = Record::BatchControl.new(self, @document).parse(records.pop)
       records.each { |r| @members << Headache::Record::Entry.new(self, @document).parse(r) }
       self
     end
 
     def descriptive_date
-      @descriptive_date || Date.today
+      @descriptive_date || Time.zone.today
     end
 
     def effective_date
-      @effective_date || Date.today
+      @effective_date || Time.zone.today
     end
 
     def initialize(document = nil)
@@ -47,21 +31,21 @@ module Headache
     def self.type_from_service_code(code)
       return :credit if code.to_s == '220'
       return :debit  if code.to_s == '225'
-      fail "unknown service code: #{code.inspect} (expecting 220 or 225)"
+      fail Headache::UnknownServiceCode, "unknown service code: #{code.inspect} (expecting 220 or 225)"
     end
 
     def service_code
       return '220' if type == :credit
       return '225' if type == :debit
-      fail "unknown batch type: #{type.inspect} (expecting :credit or :debit)"
+      fail Headache::UnknownBatchType, "unknown batch type: #{type.inspect} (expecting :credit or :debit)"
     end
 
     def header
-      @header ||= @@record_classes[:header].new self, @document
+      @header ||= Record::BatchHeader.new self, @document
     end
 
     def control
-      @control ||= @@record_classes[:control].new self, @document
+      @control ||= Record::BatchControl.new self, @document
     end
 
     def entries
@@ -73,8 +57,8 @@ module Headache
     end
 
     def to_h
-      {  batch_header: @header.to_h,
-              entries: @members.to_a.map(&:to_h),
+      { batch_header: @header.to_h,
+        entries: @members.to_a.map(&:to_h),
         batch_control: @control.to_h }
     end
 
@@ -103,6 +87,5 @@ module Headache
     def total_credit
       @total_credit || entries.map(&:amount).select { |amt| (amt || 0) > 0 }.sum
     end
-
   end
 end

--- a/lib/headache/batch.rb
+++ b/lib/headache/batch.rb
@@ -16,11 +16,11 @@ module Headache
     end
 
     def descriptive_date
-      @descriptive_date || Time.zone.today
+      @descriptive_date || Date.today
     end
 
     def effective_date
-      @effective_date || Time.zone.today
+      @effective_date || Date.today
     end
 
     def initialize(document = nil)
@@ -45,7 +45,7 @@ module Headache
     end
 
     def control
-      @control ||= Record::BatchControl.new self, @document
+      @control ||= Record::BatchControl.new self, @documentec
     end
 
     def entries

--- a/lib/headache/document.rb
+++ b/lib/headache/document.rb
@@ -2,89 +2,64 @@ module Headache
   class Document < Fixy::Document
     attr_reader :batches
 
-    LINE_SEPARATOR = "\r\n"
+    LINE_SEPARATOR = "\r\n".freeze
 
     delegate :add_entry, :'<<', to: :first_batch
 
-    @@record_classes = { batch: Batch,
-                         header: Record::FileHeader,
-                         control: Record::FileControl }
-
-    def self.header_class
-      @@record_classes[:header]
-    end
-
-    def self.control_class
-      @@record_classes[:control]
-    end
-
-    def self.header=(klass)
-      set_class :header, klass
-    end
-
-    def self.control=(klass)
-      set_class :control, klass
-    end
-
-    def self.extract_lines(string_or_file)
-      string = string_or_file.respond_to?(:read) ? string_or_file.read : string_or_file
-      string.split(LINE_SEPARATOR).reject { |line| line == Headache::Record::Overflow.new.generate.strip }
-    end
-
-    def self.cleanse_records(records)
-      invalid_lines = records.reject { |line| Headache::Record::FileHeader.record_type_codes.values.include?(line.first.to_i) }
-      raise "uknown record type(s): #{invalid_lines.map(&:first).inspect}" if invalid_lines.any?
-      records
-    end
-
-    def self.parse(string_or_file)
-      records = cleanse_records(extract_lines string_or_file)
-      header  = header_class.new(nil).parse(records.shift)
-      control = control_class.new(nil).parse(records.pop)
-      batches = get_batches(records).map { |b| Headache::Batch.new(self).parse(b) }
-      new header, control, batches
-    end
-
-    def self.get_batches(records)
-      batches = []
-      batch   = []
-      records.each do |line|
-        if line.starts_with?(Headache::Record::BatchHeader.record_type_codes[:batch_header].to_s)
-          batches << batch unless batches.empty? && batch == []
-          batch = [line]
-        else
-          batch << line
-        end
+    class << self
+      def extract_lines(string_or_file)
+        string = string_or_file.respond_to?(:read) ? string_or_file.read : string_or_file
+        string.split(LINE_SEPARATOR).reject { |line| line == Headache::Record::Overflow.new.generate.strip }
       end
-      batches << batch
-    end
 
-    def self.set_class(type, klass)
-      fail "unknown record class: #{type}" unless @@record_classes[type].present?
-      @@record_classes[type] = klass
+      def cleanse_records(records)
+        invalid_lines = records.reject { |line| Headache::Record::FileHeader.record_type_codes.values.include?(line.first.to_i) }
+        fail Headache::InvalidRecordType, "uknown record type(s): #{invalid_lines.map(&:first).inspect}" if invalid_lines.any?
+        records
+      end
+
+      def parse(string_or_file)
+        records = cleanse_records(extract_lines(string_or_file))
+        new Record::FileHeader.new(nil).parse(records.shift),
+            Record::FileControl.new(nil).parse(records.pop),
+            get_batches(records).map { |b| Headache::Batch.new(self).parse(b) }
+      end
+
+      def get_batches(records)
+        batches = []
+        batch   = []
+        records.each do |line|
+          if line.starts_with?(Headache::Record::BatchHeader.record_type_codes[:batch_header].to_s)
+            batches << batch unless batches.empty? && batch == []
+            batch = [line]
+          else
+            batch << line
+          end
+        end
+        batches << batch
+      end
     end
 
     def initialize(header = nil, control = nil, batches = [])
       @header  = header
       @control = control
       @batches = batches
-      @header.document  = self unless @header.nil?
-      @control.document = self unless @control.nil?
+      [@header, @control].each { |r| r.try :document=, self }
     end
 
     def first_batch
-      add_batch @@record_classes[:batch].new(self) if @batches.empty?
+      add_batch Batch.new(self) if @batches.empty?
       @batches.first
     end
 
     def batch
-      fail 'multiple batches detected, be more explicit or use first_batch' if @batches.count > 1
+      fail Headache::AmbiguousBatch, 'multiple batches detected, be more explicit or use first_batch' if @batches.count > 1
       first_batch
     end
 
     def add_batch(batch)
       batch.document = self
-      @batches << batch # @@record_classes[:batch].new(self)
+      @batches << batch
     end
 
     def <<(batch)
@@ -97,17 +72,17 @@ module Headache
     end
 
     def header
-      @header ||= @@record_classes[:header].new self
+      @header ||= Record::FileHeader.new self
     end
 
     def control
-      @control ||= @@record_classes[:control].new self
+      @control ||= Record::FileControl.new self
     end
 
     def records
-      ([ header ] << batches.map do |batch|
-        [ batch.header, batch.entries, batch.control ]
-      end << control).flatten # .compact
+      ([header] << batches.map do |batch|
+        [batch.header, batch.entries, batch.control]
+      end << control).flatten
     end
 
     def lines
@@ -119,8 +94,8 @@ module Headache
     end
 
     def to_h
-      {  file_header: @header.to_h,
-             batches: @batches.map(&:to_h),
+      { file_header: @header.to_h,
+        batches: @batches.map(&:to_h),
         file_control: @control.to_h }
     end
 
@@ -134,6 +109,5 @@ module Headache
       append_record control
       overflow_lines_needed.times { append_record Record::Overflow.new }
     end
-
   end
 end

--- a/lib/headache/exception.rb
+++ b/lib/headache/exception.rb
@@ -1,0 +1,16 @@
+module Headache
+  class Exception < ::RuntimeError
+  end
+
+  class InvalidRecordType < Headache::Exception
+  end
+
+  class AmbiguousBatch < Headache::Exception
+  end
+
+  class UnknownServiceCode < Headache::Exception
+  end
+
+  class UnknownBatchType < Headache::Exception
+  end
+end


### PR DESCRIPTION
This was a feature I thought might be useful, but I don't think it has any actual utility and only serves to make the code more complex.